### PR TITLE
build: use node 14 or higher

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 10, 8, 6, 4]
+        node: [15, 14, 12, 10]
     steps:
       - name: Setup repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [15, 14, 12, 10]
+        node: [14, 16, 18]
     steps:
       - name: Setup repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 10, 8, 6, 4]
+        node: [15, 14, 12, 10]
     steps:
       - name: Setup repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [15, 14, 12, 10]
+        node: [14, 16, 18]
     steps:
       - name: Setup repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 10, 8, 6, 4]
+        node: [15, 14, 12, 10]
     steps:
       - name: Setup repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [15, 14, 12, 10]
+        node: [14, 16, 18]
     steps:
       - name: Setup repo
         uses: actions/checkout@v2

--- a/index.js
+++ b/index.js
@@ -1,21 +1,8 @@
 'use strict';
 
-function pify(fn, arg1, arg2) {
-  return new Promise(function(resolve, reject) {
-    fn(arg1, arg2, function(err, data) {
-      if (err) return reject(err);
-      resolve(data);
-    });
-  });
-}
+const { promisify } = require('util');
 
-// The method startsWith is not defined on string objects in node 0.10
-// eslint-disable-next-line no-extend-native
-String.prototype.startsWith = function(suffix) {
-  return this.substring(0, suffix.length) === suffix;
-};
-
-var pidtree = require('./lib/pidtree');
+const pidtree = require('./lib/pidtree');
 
 /**
  * Get the list of children pids of the given pid.
@@ -40,7 +27,7 @@ function list(pid, options, callback) {
     return;
   }
 
-  return pify(pidtree, pid, options);
+  return promisify(pidtree)(pid, options);
 }
 
 module.exports = list;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const util = require('util');
+const util = require('node:util');
 const pidtree = require('./lib/pidtree');
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const { promisify } = require('util');
-
+const util = require('util');
 const pidtree = require('./lib/pidtree');
 
 /**
@@ -27,7 +26,7 @@ function list(pid, options, callback) {
     return;
   }
 
-  return promisify(pidtree)(pid, options);
+  return util.promisify(pidtree)(pid, options);
 }
 
 module.exports = list;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "index.d.ts"
   ],
   "engines": {
-    "node": ">= 10"
+    "node": ">= 14"
   },
   "scripts": {
     "start": "node ./bin/pidtree.js",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "index.d.ts"
   ],
   "engines": {
-    "node": ">=0.10"
+    "node": ">= 10"
   },
   "scripts": {
     "start": "node ./bin/pidtree.js",


### PR DESCRIPTION
The main point of this PR is

- Avoid to maintained out of LTS node builds
- Remove monkey patch code (`String.prototype.startsWith`) since is not more necessary
- Reduce code using `util.promisify`