### PR TITLE
Add support for WSL in vscode

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -38,7 +38,9 @@ function run(cmd, args, options, done) {
     if (executed) return;
     executed = true;
 
-    if (stderr) {
+    // Bogus screen size is a WSL-specific vscode error:
+    // https://github.com/microsoft/vscode/issues/98590
+    if (stderr && !stderr.includes('screen size is bogus')) {
       return done(new Error(stderr));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pidtree",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Cross platform children list of a PID",
   "license": "MIT",
   "homepage": "http://github.com/simonepri/pidtree#readme",

--- a/test/ps.js
+++ b/test/ps.js
@@ -95,7 +95,7 @@ test('should throw if stderr contains an error', async t => {
 
   const ps = require('../lib/ps');
 
-  await t.throws(pify(ps)())
+  await t.throws(pify(ps)());
 
   mockery.deregisterMock('child_process');
   mockery.deregisterMock('os');
@@ -110,7 +110,14 @@ test('should not throw if stderr contains the "bogus" error message from vscode'
     '   1  7166\n';
 
   mockery.registerMock('child_process', {
-    spawn: () => mocks.spawn(stdout, 'Error: your 131072x1 screen size is bogus. expect trouble', null, 0, null),
+    spawn: () =>
+      mocks.spawn(
+        stdout,
+        'Error: your 131072x1 screen size is bogus. expect trouble',
+        null,
+        0,
+        null
+      ),
   });
   mockery.registerMock('os', {
     EOL: '\n',

--- a/test/ps.js
+++ b/test/ps.js
@@ -74,3 +74,56 @@ test('should parse ps output on *nix', async t => {
   mockery.deregisterMock('child_process');
   mockery.deregisterMock('os');
 });
+
+test('should throw if stderr contains an error', async t => {
+  const stdout =
+    'PPID   PID\n' +
+    '   1   430\n' +
+    ' 430   432\n' +
+    '   1   727\n' +
+    '   1  7166\n';
+
+  mockery.registerMock('child_process', {
+    spawn: () => mocks.spawn(stdout, 'Some error', null, 0, null),
+  });
+  mockery.registerMock('os', {
+    EOL: '\n',
+    platform: () => 'linux',
+    type: () => 'type',
+    release: () => 'release',
+  });
+
+  const ps = require('../lib/ps');
+
+  await t.throws(pify(ps)())
+
+  mockery.deregisterMock('child_process');
+  mockery.deregisterMock('os');
+});
+
+test('should not throw if stderr contains the "bogus" error message from vscode', async t => {
+  const stdout =
+    'PPID   PID\n' +
+    '   1   430\n' +
+    ' 430   432\n' +
+    '   1   727\n' +
+    '   1  7166\n';
+
+  mockery.registerMock('child_process', {
+    spawn: () => mocks.spawn(stdout, 'Error: your 131072x1 screen size is bogus. expect trouble', null, 0, null),
+  });
+  mockery.registerMock('os', {
+    EOL: '\n',
+    platform: () => 'linux',
+    type: () => 'type',
+    release: () => 'release',
+  });
+
+  const ps = require('../lib/ps');
+
+  const result = await pify(ps)();
+  t.deepEqual(result, [[1, 430], [430, 432], [1, 727], [1, 7166]]);
+
+  mockery.deregisterMock('child_process');
+  mockery.deregisterMock('os');
+});


### PR DESCRIPTION
Whenever `ps` is run in a WSL window in vscode, it prints an error (a "false positive" in a way), causing to `pidtree` fail. 

This work around here is also [used in vscode itself](https://github.com/microsoft/vscode/blob/6f26fa19db7e4cd2af57f52fd7009e715c3d7aab/src/vs/base/node/ps.ts#L241).

I don't know whether you want to introduce something like this. As tiny of a change and as simple as it may be, I would understand it if you were to argue that you don't want to start including workarounds for such specific scenarios.
But in case the vscode team [either doesn't want to or is unable to address this at the source](https://github.com/microsoft/vscode/issues/145354) (this problem has existed for years), this would obviously enable `pidtree` to be used for tooling in that environment as well. (I recently contributed an [improvement to the concurrency behavior of lint-staged](https://github.com/okonet/lint-staged/pull/1117) that uses `pidtree` and that I ironically haven't been able to benefit from because I happen to use WSL...)