### PR TITLE
ci: update lint workflow action versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,11 @@ jobs:
     name: XO & Prettier
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Install dev dependencies
         run: |
           npm install --only=dev


### PR DESCRIPTION
## Issue

The GitHub Actions workflow [.github/workflows/lint.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/lint.yml) is using outdated JavaScript actions.

| Action                                                      | Used | Supported |
| ----------------------------------------------------------- | ---- | --------- |
| [actions/checkout](https://github.com/actions/checkout)     | `v2` | `v4`      |
| [actions/setup-node](https://github.com/actions/setup-node) | `v1` | `v4`      |

These actions attempt to run on `node12` (end-of-life Apr 2022) and are forcefully migrated on the fly to use instead the supported `node20` version.

Since there is no selection of a Node.js version in the use of [actions/setup-node](https://github.com/actions/setup-node), it is installing Node.js `v10.24.1` (end-of-life Apr 2021). This is in contrast to the default Node.js version of [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime) `v18.20.5` or [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#language-and-runtime) `v20.18.1`. The workflow uses `ubuntu-latest` which is currently in the process of migrating from `ubuntu-22.04` to `ubuntu-24.04`.

## Change

Update the action versions to the currently supported versions, and use [Node.js Active LTS](https://nodejs.org/en/about/releases) - at this time `v22` - as most stable recommended version.

| Action                                                      | Supported | Parameter          |
| ----------------------------------------------------------- | --------- | ------------------ |
| [actions/checkout](https://github.com/actions/checkout)     | `v4`      | N/A                |
| [actions/setup-node](https://github.com/actions/setup-node) | `v4`      | `node-version: 22` |
