### PR TITLE
ci: update ci to supported node.js 18 - 23 versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,15 +9,16 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: XO & Prettier
     steps:
       - name: Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v1
-      - name: Install dev dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
         run: |
-          npm install --only=dev
-          npm list --dev --depth=0
+          npm install
+          npm list
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -9,26 +9,21 @@ on:
 jobs:
   test:
     runs-on: macos-latest
-    name: AVA & TSD & Benchmark & Codecov
     strategy:
       fail-fast: false
       matrix:
-        node: [current, 16, 14, 12, 10, 8, 6, 4]
+        node: [23, 22, 20, 18]
     steps:
       - name: Setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - name: Install lib dependencies
+      - name: Install dependencies
         run: |
-          npm install --only=prod
-          npm list --prod --depth=0
-      - name: Install dev dependencies
-        run: |
-          npm install --only=dev
-          npm list --dev --depth=0
+          npm install
+          npm list
       - name: Run tests
         run: npm run test
       #- name: Run type checking
@@ -37,4 +32,4 @@ jobs:
         run: |
           npm run bench
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -9,26 +9,21 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: AVA & TSD & Benchmark & Codecov
     strategy:
       fail-fast: false
       matrix:
-        node: [current, 16, 14, 12, 10, 8, 6, 4]
+        node: [23, 22, 20, 18]
     steps:
       - name: Setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - name: Install lib dependencies
+      - name: Install dependencies
         run: |
-          npm install --only=prod
-          npm list --prod --depth=0
-      - name: Install dev dependencies
-        run: |
-          npm install --only=dev
-          npm list --dev --depth=0
+          npm install
+          npm list
       - name: Run tests
         run: npm run test
       #- name: Run type checking
@@ -37,4 +32,4 @@ jobs:
         run: |
           npm run bench
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -9,31 +9,22 @@ on:
 jobs:
   test:
     runs-on: windows-latest
-    name: AVA & TSD & Benchmark & Codecov
     strategy:
       fail-fast: false
       matrix:
-        node: [current, 16, 14, 12, 10, 8, 6, 4]
+        node: [23, 22, 20, 18]
     steps:
       - name: Setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - name: Install lib dependencies
+      - name: Install dependencies
         run: |
-          npm install --only=prod
-          npm list --prod --depth=0
-      - name: Install dev dependencies
-        run: |
-          npm install --only=dev
-          npm list --dev --depth=0
+          npm install
+          npm list
       - name: Run tests
-        if: ${{ matrix.node <= 6 }}
-        run: npm run test
-      - name: Run tests
-        if: ${{ !(matrix.node <= 6) }}
         run: npm run test:windows
       #- name: Run type checking
       #  run: npm run types
@@ -41,5 +32,4 @@ jobs:
         run: |
           npm run bench
       - name: Upload coverage to Codecov
-        if: ${{ matrix.node <= 6 }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5


### PR DESCRIPTION
- closes https://github.com/simonepri/pidtree/issues/22
- closes https://github.com/simonepri/pidtree/issues/23
- closes https://github.com/simonepri/pidtree/issues/24
- partially supersedes https://github.com/simonepri/pidtree/pull/12

## Issue

GitHub Action CI workflows are using versions of Node.js which cause failures. The workflows are also missing other Node.js versions which belong to the set of currently [supported Node.js versions](https://github.com/nodejs/release#release-schedule), 18 - 23.

| Workflow                                                                                                                | Uses Node.js                     |
| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [.github/workflows/test-macos.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/test-macos.yml)     | current, 16, 14, 12, 10, 8, 6, 4 |
| [.github/workflows/test-ubuntu.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/test-ubuntu.yml)   | current, 16, 14, 12, 10, 8, 6, 4 |
| [.github/workflows/test-windows.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/test-windows.yml) | current, 16, 14, 12, 10, 8, 6, 4 |
| [.github/workflows/lint.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/lint.yml)                 | environment default: `v10.24.1`  |

GitHub Action versions are not using `node20` compatible version, which is currently the only [valid value](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions).

`npm install` commands are using outdated [options](https://docs.npmjs.com/cli/v10/using-npm/config).

## Changes

For the following workflows:

- [.github/workflows/test-macos.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/test-macos.yml)
- [.github/workflows/test-ubuntu.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/test-ubuntu.yml)
- [.github/workflows/test-windows.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/test-windows.yml)
- [.github/workflows/lint.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/lint.yml)

then:

1. Modify each workflow to use the complete set of [supported Node.js versions](https://github.com/nodejs/release#release-schedule) `18.x`, `20.x`, `22.x` and `23.x`. [.github/workflows/lint.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/lint.yml) is modified to use only the Active LTS version `22.x`.
2. Update the usage of [GitHub's own actions workflows](https://github.com/actions) to supported versions:

   - [actions/checkout@v4](https://github.com/actions/checkout/releases/tag/v4.0.0)
   - [actions/setup-node@v4](https://github.com/actions/setup-node/releases/tag/v4.0.0)
3. Update the usage of GitHub action [codecov/codecov-action](https://github.com/codecov/codecov-action) to a supported version:
   - [codecov/codecov-action@v5](https://github.com/codecov/codecov-action/releases/tag/v5.0.0)
4. Remove special handling in [.github/workflows/test-windows.yml](https://github.com/simonepri/pidtree/blob/main/.github/workflows/test-windows.yml) for Node.js version dependency
5. Remove the job names `name: AVA & TSD & Benchmark & Codecov` since GitHub is unable to display this text untruncated, and the Node.js version is not visible in the summary. For consistency, also remove the `lint` job text `name: XO & Prettier` as well.
6. Merge the `npm install` `prod` and `dev` steps due to outdated options no longer available on Node.js >= 16.

## Impact

Note that this PR only updates CI. It does not update the `engines` field in [package.json](https://github.com/simonepri/pidtree/blob/main/package.json) which is currently set to 

`"node": ">=0.10"`

It does not cause any (breaking) change to the published npm package [pidtree](https://www.npmjs.com/package/pidtree) and it does not require a new release of the package.

The PR is a prerequisite for any other PRs: allowing them to be checked using CI with an expectation that CI workflows are successful.
