### PR TITLE
ci: tag releases as vX.Y.Z without the package-name prefix

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
     ".": {
       "release-type": "node",
       "package-name": "pidtree",
-      "skip-changelog": true
+      "skip-changelog": true,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
release-please defaulted to component-prefixed tags (`pidtree-v0.6.1`), which is inconsistent with the existing `v0.6.0` history and breaks the compare links. This is a single-package repo, so `include-component-in-tag: false` gives clean `v0.6.1` tags.

Once merged, release-please will update the open 0.6.1 release PR (#34) to tag `v0.6.1`.