### PR TITLE
ci: fix npm trusted publishing auth in the release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Allows manually re-running the publish step for the current release,
+  # e.g. to recover from a transient npm failure.
+  workflow_dispatch:
 
 # Restrict the default token; each job opts into what it needs.
 permissions: {}
@@ -29,7 +32,7 @@ jobs:
   # the trusted publisher must be configured for pidtree on npmjs.com.
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -39,6 +42,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      # Trusted publishing requires npm >= 11.5.0.
+          # Required for npm trusted publishing (OIDC) to authenticate.
+          registry-url: https://registry.npmjs.org
+      # Trusted publishing requires npm >= 11.5.1 (Node >= 22.14).
       - run: npm install -g npm@latest
-      - run: npm publish --provenance
+      - run: node -v && npm -v
+      # No token and no --provenance flag: with trusted publishing npm
+      # authenticates via OIDC and attaches provenance automatically.
+      - run: npm publish


### PR DESCRIPTION
The 0.6.1 publish job failed with `ENEEDAUTH` — OIDC trusted publishing never engaged. The tag `v0.6.1` and GitHub release were created fine; only the npm push failed.

Fixes, per [npm's trusted-publishing docs](https://docs.npmjs.com/trusted-publishers):
- **Set `registry-url: https://registry.npmjs.org` on setup-node** — required for OIDC to authenticate (this was the missing piece).
- **Drop `--provenance`** — trusted publishing attaches provenance automatically.
- **Add `workflow_dispatch`** so the publish can be re-run manually to recover the stuck 0.6.1 release.

After merge I'll dispatch the workflow once to publish 0.6.1, then future releases publish automatically as before.