### PR TITLE
ci: use setup-node v6 so npm OIDC trusted publishing works

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,11 +39,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # setup-node must be >= v6: older versions write a placeholder auth
+      # token to .npmrc that npm uses instead of OIDC, breaking trusted
+      # publishing. registry-url is required for OIDC to authenticate.
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          # Required for npm trusted publishing (OIDC) to authenticate.
+          node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       # Trusted publishing requires npm >= 11.5.1 (Node >= 22.14).
       - run: npm install -g npm@latest
       - run: node -v && npm -v


### PR DESCRIPTION
Second fix for the 0.6.1 publish. The previous attempt got past `ENEEDAUTH` (npm 11.16, registry-url set) but hit `E404` — `actions/setup-node@v4` writes a placeholder `_authToken` to .npmrc (visible as the `always-auth` warning + `NODE_AUTH_TOKEN: XXXXX-...`), so npm used that bogus token instead of OIDC and the registry rejected it.

`setup-node@v6` is OIDC-aware and matches [npm's documented recipe](https://docs.npmjs.com/trusted-publishers) (node 24, registry-url, no token). After merge I'll dispatch the workflow again to publish 0.6.1.