### PR TITLE
ci: drop registry-url so npm uses OIDC instead of a placeholder token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,17 +39,17 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      # setup-node must be >= v6: older versions write a placeholder auth
-      # token to .npmrc that npm uses instead of OIDC, breaking trusted
-      # publishing. registry-url is required for OIDC to authenticate.
+      # Intentionally NOT setting registry-url: it makes setup-node write a
+      # placeholder auth token to .npmrc, which npm would use instead of
+      # OIDC. npm defaults to the public registry and uses trusted
+      # publishing when no token is present.
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
-          package-manager-cache: false
       # Trusted publishing requires npm >= 11.5.1 (Node >= 22.14).
       - run: npm install -g npm@latest
       - run: node -v && npm -v
+      - run: 'echo "oidc url present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}; NODE_AUTH_TOKEN set: ${NODE_AUTH_TOKEN:+yes}"'
       # No token and no --provenance flag: with trusted publishing npm
       # authenticates via OIDC and attaches provenance automatically.
       - run: npm publish


### PR DESCRIPTION
Third fix for the stuck 0.6.1 publish.

**Diagnosis:** every failed attempt showed `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` in the publish step. `setup-node`'s `registry-url` writes a placeholder `_authToken` to .npmrc; npm then uses that bogus token **instead of** OIDC, and the registry masks the auth failure as `E404`.

Removing `registry-url` means no token is written, so npm (>= 11.5.1) falls back to OIDC trusted publishing against the default public registry. Also adds a one-line diagnostic that prints whether the OIDC token URL is present and whether a token leaked in.

After merge I'll re-dispatch on `main`. If it *still* 404s with no token present, the cause is the npm trusted-publisher config (not the workflow) — see PR discussion.